### PR TITLE
mi6 tweak

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,6 +1,7 @@
 name = DataStar
 
 [ReadmeFromPod]
+enabled = false
 filename = docs/README.rakudoc
 
 [UploadToZef]


### PR DESCRIPTION
since you have used mi6 (good), it defaults to using rakudoc to author the README and (unless you make this change) every mi6 build or release command will overwrite the README.md

this setting disables that to avoid losing your markdown readme every time