### PR TITLE
Change default interface to be the block + function interface

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{rakumod,raku,rakutest}]
+indent_size = 4

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for DataStar
 
 {{$NEXT}}
+    - Created datastar{} block and set that as the default
+    - Fixed the functions to remove ':' for sub-events.
 
 0.0.4  2025-09-21T16:18:49-04:00
     - Changed license in META6.json from Hippocratic to Artistic-2.0

--- a/META6.json
+++ b/META6.json
@@ -3,7 +3,8 @@
   "authors": [
     "Arun Vickram"
   ],
-  "build-depends": [],
+  "build-depends": [
+  ],
   "depends": [
     "JSON::Fast::Hyper"
   ],
@@ -11,14 +12,16 @@
   "license": "Artistic-2.0",
   "name": "DataStar",
   "provides": {
-    "DataStar::Constants": "lib/DataStar/Constants.rakumod",
-    "DataStar": "lib/DataStar.rakumod"
+    "DataStar": "lib/DataStar.rakumod",
+    "DataStar::Constants": "lib/DataStar/Constants.rakumod"
   },
-  "resources": [],
+  "resources": [
+  ],
   "source-url": "https://github.com/arunvickram/DataStar.git",
   "tags": [
     ""
   ],
-  "test-depends": [],
+  "test-depends": [
+  ],
   "version": "0.0.4"
 }

--- a/META6.json
+++ b/META6.json
@@ -3,25 +3,22 @@
   "authors": [
     "Arun Vickram"
   ],
-  "build-depends": [
-  ],
+  "build-depends": [],
   "depends": [
     "JSON::Fast::Hyper"
   ],
   "description": "A Raku SDK for the data-star hyper media framework",
   "license": "Artistic-2.0",
   "name": "DataStar",
-  "perl": "6.d",
   "provides": {
+    "DataStar::Constants": "lib/DataStar/Constants.rakumod",
     "DataStar": "lib/DataStar.rakumod"
   },
-  "resources": [
-  ],
+  "resources": [],
   "source-url": "https://github.com/arunvickram/DataStar.git",
   "tags": [
     ""
   ],
-  "test-depends": [
-  ],
+  "test-depends": [],
   "version": "0.0.4"
 }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,23 @@ sub routes() is export {
         }
     }
 }
+
+# in some other Cro application (with the new API)
+sub routes() is export {
+    route {
+        post -> 'validate' { 
+            content 'text/event-stream', datastar {
+                patch-elements '<div>Hello there</div>', 
+                    selector => '.validation',
+                    mode => PatchMode::AFTER;
+
+                my %new-signals = test => 2;
+
+                patch-signals %signals; 
+            }
+        }
+    }
+}
 ```
 
 DESCRIPTION

--- a/README.md
+++ b/README.md
@@ -11,23 +11,7 @@ SYNOPSIS
 ```raku
 use DataStar;
 
-# in some Cro application
-sub routes() is export {
-    route {
-        post -> 'validate' {
-            my $response = patch-elements(
-                "<div>Hello there</div>",
-                :as-supply,
-                :selector<.validation>,
-                :mode(PatchMode::AFTER)
-            );
-
-            content 'text/event-stream', $response;
-        }
-    }
-}
-
-# in some other Cro application (with the new API)
+# in your Cro application
 sub routes() is export {
     route {
         post -> 'validate' { 

--- a/docs/README.rakudoc
+++ b/docs/README.rakudoc
@@ -26,6 +26,23 @@ sub routes() is export {
     }
 }
 
+# in some other Cro application (with the new API)
+sub routes() is export {
+    route {
+        post -> 'validate' { 
+            content 'text/event-stream', datastar {
+                patch-elements '<div>Hello there</div>', 
+                    selector => '.validation',
+                    mode => PatchMode::AFTER;
+
+                my %new-signals = test => 2;
+
+                patch-signals %signals; 
+            }
+        }
+    }
+}
+
 =end code
 
 =head1 DESCRIPTION

--- a/docs/README.rakudoc
+++ b/docs/README.rakudoc
@@ -10,22 +10,6 @@ B<DataStar> - the real-time hypermedia framework, Rakufied.
 
 use DataStar;
 
-# in some Cro application
-sub routes() is export {
-    route {
-        post -> 'validate' {
-            my $response = patch-elements(
-                "<div>Hello there</div>",
-                :as-supply,
-                :selector<.validation>,
-                :mode(PatchMode::AFTER)
-            );
-
-            content 'text/event-stream', $response;
-        }
-    }
-}
-
 # in some other Cro application (with the new API)
 sub routes() is export {
     route {

--- a/docs/README.rakudoc
+++ b/docs/README.rakudoc
@@ -10,7 +10,7 @@ B<DataStar> - the real-time hypermedia framework, Rakufied.
 
 use DataStar;
 
-# in some other Cro application (with the new API)
+# in your Cro application
 sub routes() is export {
     route {
         post -> 'validate' { 

--- a/lib/DataStar.rakumod
+++ b/lib/DataStar.rakumod
@@ -19,7 +19,7 @@ multi read-signals(Str $method!, % (:Datastar-Request($), Str :$Content-Type! wh
 }
 multi read-signals($, %, %, $) { Nil }
 
-sub js-bool(Bool $raku-bool) { lc ~$raku-bool }
+sub js-bool(Bool:D $raku-bool) { lc ~$raku-bool }
 
 sub escape($s) {
     $s.subst('&', '&amp').subst("'", '&#39;').subst('"', '&#34;').subst(">", '&gt;').subst("<", '&lt;')

--- a/lib/DataStar.rakumod
+++ b/lib/DataStar.rakumod
@@ -110,12 +110,12 @@ sub remove-elements(Str $selector, Str :$event-id, Int :$retry-duration) is expo
 }
 
 multi execute-script(Str $script, Bool :$auto-remove, Positional :$attributes, Str :$event-id, Int :$retry-duration) is export {
-    my @attrs;
+    my @attrs = [
+        'data-effect="el.remove()"' if $auto-remove;
+        |$attributes if $attributes
+    ];
 
-    @attrs.push('data-effect="el.remove()"') if $auto-remove;
-    @attrs = |@attrs, |$attributes with $attributes;
-
-    my $attrs-str = @attrs.join(" ");
+    my $attrs-str = @attrs.join(' ');
 
     my $script-tag = "<script $attrs-str>" ~ $script ~ "</script>";
 

--- a/lib/DataStar.rakumod
+++ b/lib/DataStar.rakumod
@@ -1,114 +1,119 @@
-unit class DataStar;
+unit module DataStar;
 
+use DataStar::Constants;
 use JSON::Fast::Hyper;
 
-constant DEFAULT_RETRY_DURATION = 1000;
+#constant SSE_HEADERS = %{
+#    :Cache-Control<no-cache>,
+#    :Content-Type<text/event-stream>,
+#    :X-Accel-Buffering<no>
+#};
 
-enum EventType is export (:Patch-Elements<datastar-patch-elements>, :Patch-Signals<datastar-patch-signals>);
+#subset Css-Id-Selector of Str where *.starts-with('#');
+#
+#multi read-signals('GET', % (:Datastar-Request($)), % (:$datastar!), Str $) {
+#    from-json $datastar
+#}
+#multi read-signals(Str $method!, % (:Datastar-Request($), Str :$Content-Type! where 'application/json'), %params!, Str $body!) {
+#    from-json $body
+#}
+#multi read-signals($, %, %, $) { Nil }
 
-enum PatchMode is export (
-    :OUTER('outer'),
-    :INNER('inner'),
-    :REMOVE('remove'),
-    :REPLACE('replace'),
-    :PREPEND('prepend'),
-    :APPEND('append'),
-    :BEFORE('before'),
-    :AFTER('after')
-);
-
-role HTMLRenderer {
-    method HTML( --> Str:D ) {}
-    method Str ( --> Str:D ) {}
-}
-
-sub js-bool($x) {
-    if $x { 'true' } else { 'false' }
+sub js-bool(Bool $x) {
+    $x ?? 'true' !! 'false'
 }
 
 sub escape($s) {
     $s.subst('&', '&amp').subst("'", '&#39;').subst('"', '&#34;').subst(">", '&gt;').subst("<", '&lt;')
 }
+#
+#
+class SseGen is export {
+    has @!response-lines; 
 
-sub send(EventType:D $event-type, @data-lines, Str:_ :$event-id, Int:_ :$retry-duration) {
-    my @prefix = ["event: {$event-type.value}"];
-
-    with $event-id {
-        @prefix.push("id: $_");
-    }
-
-    with $retry-duration {
-        @prefix.push("retry: $_") unless $_ == DEFAULT_RETRY_DURATION;
-    }
-
-    my @data = "data: " X~ @data-lines;
-
-    [ |@prefix, |@data ].join("\n") ~ ("\n" x 2)
-}
-
-sub send-supply(EventType:D $event-type, @data-lines, Str:_ :$event-id, Int:_ :$retry-duration) {
-    supply {
-        emit("event: {$event-type.value}\n");
-        emit("id: $_\n") with $event-id;
+    method send(EventType:D $event-type, @data-lines, Str :$event-id, Int :$retry-duration) {
+        @!response-lines.push("event: {$event-type.value}\n");
+        @!response-lines.push("id: $_\n") with $event-id;
 
         with $retry-duration {
-            emit("retry: $_\n") unless $_ == DEFAULT_RETRY_DURATION;
+            @!response-lines.push("retry: $_\n") unless $_ == DEFAULT-SSE-RETRY-DURATION;
         }
 
-        emit("data: $_\n")  for @data-lines;
-        emit("\n" x 2)
+        @!response-lines.push("data: $_\n") for @data-lines;
+        @!response-lines.push("\n" x 2);
+    }
+
+    method Supply {
+        supply { 
+            emit($_) for @!response-lines; 
+        }
+    }
+
+    method Str { 
+        [~] @!response-lines 
     }
 }
 
-sub patch-elements(Str(HTMLRenderer) $elements, Str :$selector, PatchMode :$mode, Bool :$use-view-transition, Str :$event-id, Int :$retry-duration, Bool :$as-supply) is export {
+sub datastar(&f) is export {
+    my $*INSIDE-DATASTAR-RESPONSE-GENERATOR = True;
+    my $*return-as-supply = False;
+    my SseGen $*response-generator .= new;
+
+    f();
+
+    $*return-as-supply ?? $*response-generator.Supply !! $*response-generator.Str
+}
+
+sub render-as-supply {
+    fail 'You can only call this method inside a datastar { } block' unless $*INSIDE-DATASTAR-RESPONSE-GENERATOR;
+
+    $*return-as-supply = True;
+}
+
+multi patch-elements(Str $elements, Str :$selector, ElementPatchMode :$mode, Bool :$use-view-transition, Str :$event-id, Int :$retry-duration) is export {
+    fail 'You can only call this method inside a datastar { } block' unless $*INSIDE-DATASTAR-RESPONSE-GENERATOR;
+
     my @data-lines;
 
     with $mode {
-        @data-lines.push("mode: {.value}") unless $_ == PatchMode::OUTER;
+        @data-lines.push("{MODE-DATALINE-LITERAL}: {.value}") unless $_ == ElementPatchMode::OUTER;
     }
 
-    @data-lines.push("selector: $_") with $selector;
-
-    @data-lines.push("useViewTransition: {js-bool($use-view-transition)}") if $use-view-transition;
+    @data-lines.push("{SELECTOR-DATALINE-LITERAL}: $_") with $selector;
+    @data-lines.push("{USE-VIEW-TRANSITION-DATALINE-LITERAL}: {js-bool($use-view-transition)}") if $use-view-transition;
 
     with $elements {
-        my @element-lines = "elements: " X~ $_.split("\n");
+        my @element-lines = "{ELEMENTS-DATALINE-LITERAL}: " X~ $_.split("\n");
         @data-lines = |@data-lines, |@element-lines;
     }
 
-    if $as-supply {
-        send-supply(EventType::Patch-Elements, @data-lines, :$event-id, :$retry-duration)
-    } else {
-        send(EventType::Patch-Elements, @data-lines, :$event-id, :$retry-duration)
-    }
+    $*response-generator.send: EventType::Patch-Elements, @data-lines, :$event-id, :$retry-duration;
 }
 
-multi sub patch-signals(Str $signals, Str :$event-id, Bool :$only-if-missing, Int :$retry-duration, Bool :$as-supply) is export {
+multi patch-signals( Str $signals, Str :$event-id, Bool :$only-if-missing, Int :$retry-duration ) is export {
+    fail 'You can only call this method inside a datastar { } block' unless $*INSIDE-DATASTAR-RESPONSE-GENERATOR;
+
     my @data-lines;
 
     if $only-if-missing {
-        @data-lines.push("onlyIfMissing: {js-bool($only-if-missing)}");
+        @data-lines.push("{ONLY-IF-MISSING-DATALINE-LITERAL}: {js-bool($only-if-missing)}");
     }
 
-    my @signal-lines = "signals: " X~ $signals.split("\n");
+    my @signal-lines = "{SIGNALS-DATALINE-LITERAL}: " X~ $signals.split("\n");
     @data-lines = |@data-lines, |@signal-lines;
 
-    if $as-supply {
-        send-supply(EventType::Patch-Signals, @data-lines, :$event-id, :$retry-duration)
-    } else {
-        send(EventType::Patch-Signals, @data-lines, :$event-id, :$retry-duration)
-    }
+    $*response-generator.send: EventType::Patch-Signals, @data-lines, :$event-id, :$retry-duration;
 }
 
-multi sub patch-signals(%signals, Str :$event-id, Bool :$only-if-missing, Int :$retry-duration, Bool :$as-supply) {
-    patch-signals(to-json(%signals), :$event-id, :$only-if-missing, :$retry-duration, :$as-supply)
+multi patch-signals( %signals, *%options ) {
+    samewith to-json(%signals, :!pretty), |%options;
 }
 
-sub remove-elements(Str $selector, Str :$event-id, Int :$retry-duration, Bool :$as-supply) is export {
-    patch-elements(Str, :$selector, :mode(PatchMode::REMOVE), :$event-id, :$retry-duration, :$as-supply)
+sub remove-elements(Str $selector, Str :$event-id, Int :$retry-duration) is export {
+    patch-elements Str, :$selector, :mode(ElementPatchMode::REMOVE), :$event-id, :$retry-duration
 }
 
-multi sub execute-script(Str $script, Bool :$auto-remove, Array :$attributes, Str :$event-id, Int :$retry-duration, Bool :$as-supply) is export {
+multi execute-script(Str $script, Bool :$auto-remove, Positional :$attributes, Str :$event-id, Int :$retry-duration) is export {
     my $attr-str = "";
 
     $attr-str ~= ' data-effect="el.remove()"' if $auto-remove;
@@ -116,27 +121,104 @@ multi sub execute-script(Str $script, Bool :$auto-remove, Array :$attributes, St
 
     my $script-tag = "<script $attr-str>" ~ $script ~ "</script>";
 
-    patch-elements($script-tag, :selector<body>, :mode(PatchMode::APPEND), :$event-id, :$retry-duration, :$as-supply)
+    patch-elements $script-tag, :selector<body>, :mode(ElementPatchMode::APPEND), :$event-id, :$retry-duration
 }
 
-
-multi sub execute-script(Str $script, Bool :$auto-remove, :@attributes, Str :$event-id, Int :$retry-duration, Bool :$as-supply) {
-    my $attr-str = "";
-
-    $attr-str ~= ' data-effect="el.remove()"' if $auto-remove;
-    $attr-str ~= @attributes.join(" ") if @attributes;
-
-    my $script-tag = "<script $attr-str>" ~ $script ~ "</script>";
-
-    patch-elements($script-tag, :selector<body>, :mode(PatchMode::APPEND), :$event-id, :$retry-duration, :$as-supply)
-}
-
-multi sub execute-script(Str $script, Bool :$auto-remove, :%attributes, Str :$event-id, Int :$retry-duration, Bool :$as-supply) {
-    my @attributes = [ "{escape(.key)}=\"{escape(.value)}\"" for %attributes.pairs ];
-    execute-script($script, :$auto-remove, :@attributes, :$event-id, :$retry-duration, :$as-supply)
-}
-
-multi sub execute-script(Str $script, Bool :$auto-remove, Hash :$attributes, Str :$event-id, Int :$retry-duration, Bool :$as-supply) {
+multi execute-script(Str $script, Bool :$auto-remove, Associative :$attributes, Str :$event-id, Int :$retry-duration) is export {
     my @attributes = [ "{escape(.key)}=\"{escape(.value)}\"" for $attributes.pairs ];
-    execute-script($script, :$auto-remove, :@attributes, :$event-id, :$retry-duration, :$as-supply)
+    samewith $script, :$auto-remove, :@attributes, :$event-id, :$retry-duration
+}
+
+class ServerSentEventGenerator is export {
+    method send(EventType:D $event-type, @data-lines, Str :$event-id, Int :$retry-duration) {
+        my @prefix = ["event: {$event-type.value}"];
+
+        @prefix.push("id: $_") with $event-id;
+
+        with $retry-duration {
+            @prefix.push("retry: $_") unless $_ == DEFAULT-SSE-RETRY-DURATION;
+        }
+
+        my @data = "data: " X~ @data-lines;
+
+        [ |@prefix, |@data ].join("\n") ~ ("\n" x 2)
+    }
+
+    method send-supply(EventType:D $event-type, @data-lines, Str :$event-id, Int :$retry-duration) {
+        supply {
+            emit("event: {$event-type.value}\n");
+            emit("id: $_\n") with $event-id;
+
+            with $retry-duration {
+                emit("retry: $_\n") unless $_ == DEFAULT-SSE-RETRY-DURATION;
+            }
+
+            emit("data: $_\n") for @data-lines;
+            emit("\n" x 2)
+        }
+    }
+
+    method patch-elements(Str $elements, Str :$selector, ElementPatchMode :$mode, Bool :$use-view-transition, Str :$event-id, Int :$retry-duration, Bool :$as-supply) {
+        my @data-lines;
+
+        with $mode {
+            @data-lines.push("{MODE-DATALINE-LITERAL}: {.value}") unless $_ == ElementPatchMode::OUTER;
+        }
+
+        @data-lines.push("{SELECTOR-DATALINE-LITERAL}: $_") with $selector;
+
+        @data-lines.push("{USE-VIEW-TRANSITION-DATALINE-LITERAL}: {js-bool($use-view-transition)}") if $use-view-transition;
+
+        with $elements {
+            my @element-lines = "{ELEMENTS-DATALINE-LITERAL}: " X~ $_.split("\n");
+            @data-lines = |@data-lines, |@element-lines;
+        }
+
+        if $as-supply {
+            self.send-supply: EventType::Patch-Elements, @data-lines, :$event-id, :$retry-duration
+        } else {
+            self.send: EventType::Patch-Elements, @data-lines, :$event-id, :$retry-duration
+        }
+    }
+
+    multi method patch-signals(Str $signals, Str :$event-id, Bool :$only-if-missing, Int :$retry-duration, Bool :$as-supply) {
+        my @data-lines;
+
+        if $only-if-missing {
+            @data-lines.push("{ONLY-IF-MISSING-DATALINE-LITERAL}: {js-bool($only-if-missing)}");
+        }
+
+        my @signal-lines = "{SIGNALS-DATALINE-LITERAL}: " X~ $signals.split("\n");
+        @data-lines = |@data-lines, |@signal-lines;
+
+        if $as-supply {
+            self.send-supply(EventType::Patch-Signals, @data-lines, :$event-id, :$retry-duration)
+        } else {
+            self.send(EventType::Patch-Signals, @data-lines, :$event-id, :$retry-duration)
+        }
+    }
+
+    multi method patch-signals(%signals, Str :$event-id, Bool :$only-if-missing, Int :$retry-duration, Bool :$as-supply) {
+        self.patch-signals(to-json(%signals), :$event-id, :$only-if-missing, :$retry-duration, :$as-supply)
+    }
+
+    multi method remove-elements(Str $selector, Str :$event-id, Int :$retry-duration, Bool :$as-supply) {
+        self.patch-elements(Str, :$selector, :mode(ElementPatchMode::REMOVE), :$event-id, :$retry-duration, :$as-supply)
+    }
+
+    multi method execute-script(Str $script, Bool :$auto-remove, Positional :$attributes, Str :$event-id, Int :$retry-duration, Bool :$as-supply) {
+        my $attr-str = "";
+
+        $attr-str ~= ' data-effect="el.remove()"' if $auto-remove;
+        $attr-str ~= $attributes.join(" ") if $attributes;
+
+        my $script-tag = "<script $attr-str>" ~ $script ~ "</script>";
+
+        self.patch-elements($script-tag, :selector<body>, :mode(ElementPatchMode::APPEND), :$event-id, :$retry-duration, :$as-supply)
+    }
+
+    multi method execute-script(Str $script, Bool :$auto-remove, Associative :$attributes, Str :$event-id, Int :$retry-duration, Bool :$as-supply) {
+        my @attributes = [ "{escape(.key)}=\"{escape(.value)}\"" for $attributes.pairs ];
+        samewith($script, :$auto-remove, :@attributes, :$event-id, :$retry-duration, :$as-supply)
+    }
 }

--- a/lib/DataStar.rakumod
+++ b/lib/DataStar.rakumod
@@ -115,9 +115,9 @@ multi execute-script(Str $script, Bool :$auto-remove, Positional :$attributes, S
         |$attributes if $attributes
     ];
 
-    my $attrs-str = @attrs.join(' ');
+    my $attrs = @attrs ?? ' ' ~ @attrs.join(' ') !! '';
 
-    my $script-tag = "<script $attrs-str>" ~ $script ~ "</script>";
+    my $script-tag = "<script$attrs>" ~ $script ~ "</script>";
 
     patch-elements $script-tag, :selector<body>, :mode(ElementPatchMode::APPEND), :$event-id, :$retry-duration
 }

--- a/lib/DataStar.rakumod
+++ b/lib/DataStar.rakumod
@@ -19,7 +19,7 @@ multi read-signals(Str $method!, % (:Datastar-Request($), Str :$Content-Type! wh
 }
 multi read-signals($, %, %, $) { Nil }
 
-sub js-bool(Bool:D $raku-bool) { lc ~$raku-bool }
+sub js-bool(Bool $raku-bool) { lc ~?$raku-bool }
 
 sub escape($s) {
     $s.subst('&', '&amp').subst("'", '&#39;').subst('"', '&#34;').subst(">", '&gt;').subst("<", '&lt;')
@@ -112,7 +112,7 @@ sub remove-elements(Str $selector, Str :$event-id, Int :$retry-duration) is expo
 multi execute-script(Str $script, Bool :$auto-remove, Positional :$attributes, Str :$event-id, Int :$retry-duration) is export {
     my @attrs;
 
-    @attrs.push('data-effects="el.remove()') if $auto-remove;
+    @attrs.push('data-effect="el.remove()"') if $auto-remove;
     @attrs = |@attrs, |$attributes with $attributes;
 
     my $attrs-str = @attrs.join(" ");

--- a/lib/DataStar/Constants.rakumod
+++ b/lib/DataStar/Constants.rakumod
@@ -1,19 +1,19 @@
 unit module DataStar::Constants;
 
 enum EventType is export (
-  Patch-Elements => 'datastar-patch-elements',
-  Patch-Signals  => 'datastar-patch-signals'
+    PatchElements => 'datastar-patch-elements',
+    PatchSignals  => 'datastar-patch-signals'
 );
 
 enum ElementPatchMode is export (
-  OUTER   => 'outer',
-  INNER   => 'inner',
-  REMOVE  => 'remove',
-  REPLACE => 'replace',
-  PREPEND => 'prepend',
-  APPEND  => 'append',
-  BEFORE  => 'before',
-  AFTER   => 'after'
+    OUTER   => 'outer',
+    INNER   => 'inner',
+    REMOVE  => 'remove',
+    REPLACE => 'replace',
+    PREPEND => 'prepend',
+    APPEND  => 'append',
+    BEFORE  => 'before',
+    AFTER   => 'after'
 );
 
 constant SELECTOR-DATALINE-LITERAL             is export = "selector";
@@ -22,8 +22,6 @@ constant ELEMENTS-DATALINE-LITERAL             is export = "elements";
 constant USE-VIEW-TRANSITION-DATALINE-LITERAL  is export = "useViewTransition";
 constant SIGNALS-DATALINE-LITERAL              is export = "signals";
 constant ONLY-IF-MISSING-DATALINE-LITERAL      is export = "onlyIfMissing";
-
 constant DEFAULT-SSE-RETRY-DURATION            is export = 1000;
-
 constant DEFAULT-ELEMENTS-USE-VIEW-TRANSITIONS is export = False;
 constant DEFAULT-PATCH-SIGNALS-ONLY-IF-MISSING is export = False;

--- a/lib/DataStar/Constants.rakumod
+++ b/lib/DataStar/Constants.rakumod
@@ -1,0 +1,29 @@
+unit module DataStar::Constants;
+
+enum EventType is export (
+  Patch-Elements => 'datastar-patch-elements',
+  Patch-Signals  => 'datastar-patch-signals'
+);
+
+enum ElementPatchMode is export (
+  OUTER   => 'outer',
+  INNER   => 'inner',
+  REMOVE  => 'remove',
+  REPLACE => 'replace',
+  PREPEND => 'prepend',
+  APPEND  => 'append',
+  BEFORE  => 'before',
+  AFTER   => 'after'
+);
+
+constant SELECTOR-DATALINE-LITERAL             is export = "selector";
+constant MODE-DATALINE-LITERAL                 is export = "mode";
+constant ELEMENTS-DATALINE-LITERAL             is export = "elements";
+constant USE-VIEW-TRANSITION-DATALINE-LITERAL  is export = "useViewTransition";
+constant SIGNALS-DATALINE-LITERAL              is export = "signals";
+constant ONLY-IF-MISSING-DATALINE-LITERAL      is export = "onlyIfMissing";
+
+constant DEFAULT-SSE-RETRY-DURATION            is export = 1000;
+
+constant DEFAULT-ELEMENTS-USE-VIEW-TRANSITIONS is export = False;
+constant DEFAULT-PATCH-SIGNALS-ONLY-IF-MISSING is export = False;

--- a/t/1-patch-elements-test.rakutest
+++ b/t/1-patch-elements-test.rakutest
@@ -1,7 +1,23 @@
 use Test;
 use DataStar;
+use DataStar::Constants;
 
-like patch-elements("<div></div>", :selector<hello>), /data: /;
-like patch-elements("<div></div>", :selector<hello>), /elements: /;
+#lives-ok { datastar { patch-elements '<div></div>' } };
+#
+#like $test, /elements: /, 'failed elements';
+
+my $basic-patched-elements = datastar {
+    patch-elements 
+        "<div></div>", 
+        selector => '#id',
+        use-view-transition => True;
+};
+
+like $basic-patched-elements, /data: /, "SSE response should contain data:";
+like $basic-patched-elements, /elements: /, "SSE response should contain elements:";
+like $basic-patched-elements, /selector: /, "SSE response should contain selector:";
+
+#like ServerSentEventGenerator.patch-elements("<div></div>", :selector<hello>), /data: /, "failed data";
+#like ServerSentEventGenerator.patch-elements("<div></div>", :selector<hello>), /elements: /, "failed elements";
 
 done-testing;

--- a/t/1-patch-elements.rakutest
+++ b/t/1-patch-elements.rakutest
@@ -14,10 +14,7 @@ my $basic-patched-elements = datastar {
 };
 
 like $basic-patched-elements, /data: /, "SSE response should contain data:";
-like $basic-patched-elements, /elements: /, "SSE response should contain elements:";
-like $basic-patched-elements, /selector: /, "SSE response should contain selector:";
-
-#like ServerSentEventGenerator.patch-elements("<div></div>", :selector<hello>), /data: /, "failed data";
-#like ServerSentEventGenerator.patch-elements("<div></div>", :selector<hello>), /elements: /, "failed elements";
+like $basic-patched-elements, /elements /, "SSE response should contain elements:";
+like $basic-patched-elements, /selector /, "SSE response should contain selector:";
 
 done-testing;

--- a/t/2-patch-signals-test.rakutest
+++ b/t/2-patch-signals-test.rakutest
@@ -1,6 +1,0 @@
-use Test;
-use DataStar;
-
-is 'hello', 'hello';
-
-done-testing;


### PR DESCRIPTION
instead of writing your datastar + cro code like this:

```raku
my $response = patch-elements "<div></div>", |%options; 
my $response-2 = patch-signals { a => 2, b => 3 };

content 'text/event-stream', $response ~ $response-2
```

write it like this:

```raku
content 'text/event-stream', datastar {
    patch-elements "<div></div>", |%options;
    patch-signals { a => 2, b => 3 }; 
    remove-elements '#id';
    execute-script '$i += ';
}
```